### PR TITLE
Fix documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ sudo apt remove superunko
 * With Homebrew
 
 ```
-$ brew tap unkontributors/tools
+$ brew tap unkontributors/unko
 $ brew install super_unko
 ```
 

--- a/doc/unko.puzzle.md
+++ b/doc/unko.puzzle.md
@@ -52,12 +52,28 @@ $ brew install xdotool
 1. Launch xterm.
     ```sh
     $ PATH=$PATH:/opt/X11/bin xterm &
-    ```sh
+    ```
 1. Run `unko.puzzle` on xterm.
     ```sh
     $ unko.puzzle
     ```
 1. Enjoy!
+
+---
+
+```
+Warning: XTEST extension unavailable on '(null)'.
+Some functionality may be disabled; See 'man xdotool' for more info.
+```
+
+If you received such a message from xdotool, you may be able to resolve it by execute the following commands and restarting XQuartz:
+
+```sh
+$ defaults write org.x.X11 enable_test_extensions -boolean true
+$ defaults write org.macosforge.xquartz.X11 enable_test_extensions -boolean true
+```
+
+See: https://stackoverflow.com/questions/1264210/does-mac-x11-have-the-xtest-extension
 
 ## for development
 


### PR DESCRIPTION
- Homebrew のリポジトリ名が誤っていたようなので、README の方を修正しました

```sh
$ brew tap unkontributors/tools
==> Tapping unkontributors/tools
Cloning into '/usr/local/Homebrew/Library/Taps/unkontributors/homebrew-tools'...
remote: Repository not found.
fatal: repository 'https://github.com/unkontributors/homebrew-tools/' not found
Error: Failure while executing; `git clone https://github.com/unkontributors/homebrew-tools /usr/local/Homebrew/Library/Taps/unkontributors/homebrew-tools --depth=1` exited with 128.
```

- ついでに unko.puzzle のドキュメントも追記しました

💩よろしくおねがいします💩