### PR TITLE
Fix/improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,11 @@ install:
   - sudo apt-get install -qq bats
   - bats --version
   - GO111MODULE=off go get mvdan.cc/sh/cmd/shfmt
+  - alias shellcheck='docker run -v "$PWD:/mnt" koalaman/shellcheck'
+  - bash --version
+  - shellcheck --version
 
 script:
-  - alias shellcheck='docker run -v "$PWD:/mnt" koalaman/shellcheck'
   - ls -1 bin/* | grep -v unko.puzzle | xargs shfmt -i 2 -ci -sr -d
   - ls -1 bin/* | grep -v unko.puzzle | xargs shellcheck
   - shfmt -i 2 -ci -sr -d test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: bash
 matrix:
   include:
     - os: linux
+      env: SH_VERSION=default
+    - os: linux
       env: SH_VERSION=3.2
     - os: linux
       env: SH_VERSION=4.0
@@ -30,6 +32,10 @@ addons:
 before_install:
   - sudo add-apt-repository ppa:duggan/bats --yes
   - sudo apt-get update -qq
+  ## Install bash
+  - export TMPDIR=$TRAVIS_BUILD_DIR/tmp
+  - mkdir -p $TMPDIR
+  - if [[ "$SH_VERSION" != "default" ]];then ( cd "$TMPDIR" && curl "http://ftp.gnu.org/gnu/bash/bash-${SH_VERSION}.tar.gz" | tar xvz && cd bash* && ./configure; make && sudo make install && sudo mv /bin/bash /bin/bash.old && sudo cp ./bash /bin/bash ) ;fi
 
 install:
   - sudo apt-get install -qq bats

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
       - gcc
       - make
       - golang
-      - shellcheck
 
 before_install:
   - sudo add-apt-repository ppa:duggan/bats --yes
@@ -36,6 +35,7 @@ before_install:
   - export TMPDIR=$TRAVIS_BUILD_DIR/tmp
   - mkdir -p $TMPDIR
   - if [[ "$SH_VERSION" != "default" ]];then ( cd "$TMPDIR" && curl "http://ftp.gnu.org/gnu/bash/bash-${SH_VERSION}.tar.gz" | tar xvz && cd bash* && ./configure; make && sudo make install && sudo mv /bin/bash /bin/bash.old && sudo cp ./bash /bin/bash ) ;fi
+  - docker pull koalaman/shellcheck:stable ## Official docker container (v0.6.0 or later)
 
 install:
   - sudo apt-get install -qq bats
@@ -43,6 +43,7 @@ install:
   - GO111MODULE=off go get mvdan.cc/sh/cmd/shfmt
 
 script:
+  - alias shellcheck='docker run -v "$PWD:/mnt" koalaman/shellcheck'
   - ls -1 bin/* | grep -v unko.puzzle | xargs shfmt -i 2 -ci -sr -d
   - ls -1 bin/* | grep -v unko.puzzle | xargs shellcheck
   - shfmt -i 2 -ci -sr -d test.sh


### PR DESCRIPTION
* 設定していた `SH_VERSION` が効果を成していなかったので修正
* `shellcheck` は確実に最新版を使えるようにdockerコンテナ版を利用 (理由: [個人的な教訓](https://github.com/greymd/echo-meme/pull/4))