### PR TITLE
shfmtとshellcheckを実行するためのスクリプトを追加 (#41)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ addons:
     packages:
       - figlet
       - toilet
-      - gcc
-      - make
-      - golang
 
 before_install:
   - sudo add-apt-repository ppa:duggan/bats --yes
@@ -35,20 +32,14 @@ before_install:
   - export TMPDIR=$TRAVIS_BUILD_DIR/tmp
   - mkdir -p $TMPDIR
   - if [[ "$SH_VERSION" != "default" ]];then ( cd "$TMPDIR" && curl "http://ftp.gnu.org/gnu/bash/bash-${SH_VERSION}.tar.gz" | tar xvz && cd bash* && ./configure; make && sudo make install && sudo mv /bin/bash /bin/bash.old && sudo cp ./bash /bin/bash ) ;fi
-  - docker pull koalaman/shellcheck:stable ## Official docker container (v0.6.0 or later)
+  - bash --version
 
 install:
   - sudo apt-get install -qq bats
   - bats --version
-  - GO111MODULE=off go get mvdan.cc/sh/cmd/shfmt
-  - alias shellcheck='docker run -v "$PWD:/mnt" koalaman/shellcheck'
-  - bash --version
-  - shellcheck --version
+  - ./linter.sh setup
 
 script:
   - sudo ./install.sh
-  - ls -1 bin/* | grep -v unko.puzzle | xargs shfmt -i 2 -ci -sr -d
-  - ls -1 bin/* | grep -v unko.puzzle | xargs shellcheck
-  - shfmt -i 2 -ci -sr -d test.sh
-  - shellcheck test.sh
+  - ./linter.sh all
   - ./test.sh

--- a/README.md
+++ b/README.md
@@ -132,8 +132,57 @@ $ ./unko.yes
 ...
 ```
 
-Testing
+Development
 ========================
+
+### Codestyle and lint
+
+We are checking code with [shfmt](https://github.com/mvdan/sh) and [shellcheck](https://github.com/koalaman/shellcheck).
+Please you check your code by `linter.sh` if you will want to add your origin unko commands.
+We must provides clean unkos.
+So, please you run below and pass all checkings.
+
+```bash
+./linter.sh all
+```
+
+`linter.sh` check your code or all code of this project.
+**linter.sh depends on docker and docker-compose commands.**
+And you **don't** need to install shfmt and shellcheck.
+
+Usage examples of `linter.sh` are below.
+
+#### Help
+
+```bash
+./linter.sh help
+```
+
+#### Code format
+
+```bash
+./linter.sh format
+```
+
+#### Code format and save
+
+```bash
+./linter.sh format-save
+```
+
+#### Code lint
+
+```bash
+./linter.sh lint
+```
+
+#### Code format and lint
+
+```bash
+./linter.sh all
+```
+
+### Testing
 
 We use the [bats](https://github.com/sstephenson/bats) testing framework.
 Please you install that.
@@ -162,5 +211,9 @@ History
 For Unkontributors (開発者向け)
 ========================
 bin 以下になんか思いついたコマンドを放り投げてください。
-決まったルールとか運用は特に無いです。
 docker が入った環境で `bash package.sh` すると pkg 以下に各種インストーラーが作成されることだけ知っておいてください。
+
+CIでコードフォーマットと静的解析にかけてコード品質を維持するようになりました。
+PRするときは`./linter.sh all`で静的解析をパスすることを確認してください。
+
+可能なら`./test.sh`にもテストコードを追加していただけると助かります。

--- a/bin/super_unko
+++ b/bin/super_unko
@@ -84,7 +84,7 @@ to_command_path() {
   for cmd_fullpath in "$THIS_DIR/bigunko".*; do
     local big_cmd=${cmd//big/bigunko.}
     local c=${cmd_fullpath##*/}
-    if [[ "$c" = "$big_cmd" ]]; then
+    if [[ "$c" == "$big_cmd" ]]; then
       echo "$cmd_fullpath"
       return
     fi
@@ -92,7 +92,7 @@ to_command_path() {
 
   for cmd_fullpath in "$THIS_DIR/unko".*; do
     local c=${cmd_fullpath##*/unko.}
-    if [[ "$c" = "$cmd" ]]; then
+    if [[ "$c" == "$cmd" ]]; then
       echo "$cmd_fullpath"
       return
     fi

--- a/bin/unko.puzzle
+++ b/bin/unko.puzzle
@@ -2,7 +2,7 @@
 set -eu
 FRAME=30
 TILES=${TILES:-3}
-HEADER_HEIGHT=23  # Darwin
+HEADER_HEIGHT=23 # Darwin
 RANDOM_SLIDE=$((10 + TILES * TILES * TILES / 2))
 PIXEL_ART_COLS=60 # BIGUNKO'
 PIXEL_ART_ROWS=30 # BIGUNKO
@@ -22,15 +22,15 @@ initialize() {
   # process stratum: this process -> shell(bash) -> terminal emulator ?
   pppid=$(ps -ef | awk "\$2==$PPID{print \$3}")
   case $platform in
-    'Darwin' )
+    'Darwin')
       HEIGHT_OFFSET=-44
       WIDTH_OFFSET=0
       ;;
-    'Linux' )
+    'Linux')
       HEIGHT_OFFSET=-68
       WIDTH_OFFSET=-10
       ;;
-    * )
+    *)
       echo "error: $platform: unsupported platform" >&2
       exit 1
       ;;
@@ -41,7 +41,7 @@ initialize() {
     exit 1
   fi
 
-  which xdotool >/dev/null 2>&1 || {
+  which xdotool > /dev/null 2>&1 || {
     echo 'error: require xdotool' >&2
     exit 1
   }
@@ -127,14 +127,17 @@ trim_bigunko() {
   local tile_pos_x=$1 tile_pos_y=$2
   if [ "$BIGUNKO" == "" ]; then
     # cache bigunko to prevent broken pipe error
-    BIGUNKO=$($(cd $(dirname $0);pwd)/bigunko.show | sed $'s/\(\033\[48;5;[0-9]*m\)　/\\1 \\1 /g')
+    BIGUNKO=$($(
+      cd $(dirname $0)
+      pwd
+    )/bigunko.show | sed $'s/\(\033\[48;5;[0-9]*m\)　/\\1 \\1 /g')
   fi
 
-  echo "$BIGUNKO" \
-  | head -n $(($tile_char_rows * ($tile_pos_y + 1) )) \
-  | tail -n $tile_char_rows \
-  | sed $'s/\(\033\[48;5;[0-9]*m\)　/\\1 \\1 /g' \
-  | awk "
+  echo "$BIGUNKO" |
+    head -n $(($tile_char_rows * ($tile_pos_y + 1))) |
+    tail -n $tile_char_rows |
+    sed $'s/\(\033\[48;5;[0-9]*m\)　/\\1 \\1 /g' |
+    awk "
     {
       for (k = $tile_char_cols * $tile_pos_x + 1; k < $tile_char_cols * ($tile_pos_x + 1) + 1; k++) {
         printf \$k\" \";
@@ -161,10 +164,10 @@ draw() {
   local tile_pos_x=1 tile_pos_y=0
   log_debug "draw window: root; tile position=$tile_pos_x,$tile_pos_y"
   trim_bigunko $tile_pos_x $tile_pos_y
-  for i in $(seq 0 $((${#tty_names[@]}-1))); do
+  for i in $(seq 0 $((${#tty_names[@]} - 1))); do
     tile_pos_x=$((($i + 2) % $TILES))
     tile_pos_y=$((($i + 2) / $TILES))
-    log_debug "draw window: child $((i+1)); tile position=$tile_pos_x,$tile_pos_y; tty=/dev/${tty_names[i]}"
+    log_debug "draw window: child $((i + 1)); tile position=$tile_pos_x,$tile_pos_y; tty=/dev/${tty_names[i]}"
     trim_bigunko $tile_pos_x $tile_pos_y >> /dev/${tty_names[i]}
   done
 }
@@ -202,9 +205,9 @@ shake_window() {
   local pos_y=${pos#*,}
   for i in $(seq 5); do
     xdotool windowmove $wid $(($pos_x - 10 + $WIDTH_OFFSET)) $(($pos_y + $HEIGHT_OFFSET))
-    xdotool windowmove $wid $(($pos_x      + $WIDTH_OFFSET)) $(($pos_y + $HEIGHT_OFFSET))
+    xdotool windowmove $wid $(($pos_x + $WIDTH_OFFSET)) $(($pos_y + $HEIGHT_OFFSET))
     xdotool windowmove $wid $(($pos_x + 10 + $WIDTH_OFFSET)) $(($pos_y + $HEIGHT_OFFSET))
-    xdotool windowmove $wid $(($pos_x      + $WIDTH_OFFSET)) $(($pos_y + $HEIGHT_OFFSET))
+    xdotool windowmove $wid $(($pos_x + $WIDTH_OFFSET)) $(($pos_y + $HEIGHT_OFFSET))
   done
 }
 
@@ -212,10 +215,10 @@ can_slide() {
   local null_index=$1
   local direction=$2
   case $direction in
-    'up')    if [ $null_index -lt $(($TILES * $TILES - $TILES)) ]; then return 0; fi ;;
-    'down')  if [ $null_index -ge $TILES ];                        then return 0; fi ;;
-    'left')  if [ $(($null_index % $TILES)) -ne $(($TILES - 1)) ]; then return 0; fi ;;
-    'right') if [ $(($null_index % $TILES)) -ne 0 ];               then return 0; fi ;;
+    'up') if [ $null_index -lt $(($TILES * $TILES - $TILES)) ]; then return 0; fi ;;
+    'down') if [ $null_index -ge $TILES ]; then return 0; fi ;;
+    'left') if [ $(($null_index % $TILES)) -ne $(($TILES - 1)) ]; then return 0; fi ;;
+    'right') if [ $(($null_index % $TILES)) -ne 0 ]; then return 0; fi ;;
   esac
   return 1
 }
@@ -258,9 +261,9 @@ move_tile() {
   else
     if [ "$anotation" = 'true' ]; then
       case $direction in
-        'up')    target_index=$(($null_index - $TILES)) ;;
-        'down')  target_index=$(($null_index + $TILES)) ;;
-        'left')  target_index=$(($null_index - 1)) ;;
+        'up') target_index=$(($null_index - $TILES)) ;;
+        'down') target_index=$(($null_index + $TILES)) ;;
+        'left') target_index=$(($null_index - 1)) ;;
         'right') target_index=$(($null_index + 1)) ;;
       esac
       wid=${WIDS[$target_index]}
@@ -276,10 +279,22 @@ randomize() {
   while [ $count -le $RANDOM_SLIDE ]; do
     local rand=$((RANDOM % 4))
     case $rand in
-      0) direction='up';    if [ $prev -eq 1 ]; then continue; fi ;;
-      1) direction='down';  if [ $prev -eq 0 ]; then continue; fi ;;
-      2) direction='left';  if [ $prev -eq 3 ]; then continue; fi ;;
-      3) direction='right'; if [ $prev -eq 2 ]; then continue; fi ;;
+      0)
+        direction='up'
+        if [ $prev -eq 1 ]; then continue; fi
+        ;;
+      1)
+        direction='down'
+        if [ $prev -eq 0 ]; then continue; fi
+        ;;
+      2)
+        direction='left'
+        if [ $prev -eq 3 ]; then continue; fi
+        ;;
+      3)
+        direction='right'
+        if [ $prev -eq 2 ]; then continue; fi
+        ;;
     esac
     local null_index=$(echo "${WIDS[@]}" | tr ' ' '\n' | nl -v0 | grep null | awk '{print $1}')
     if can_slide $null_index $direction; then
@@ -299,14 +314,18 @@ solve() {
       key+="$rest"
     fi
     case "$key" in
-      k|$'\x1b\x5b\x41')
-        move_tile 'up' 'true' ;;
-      j|$'\x1b\x5b\x42')
-        move_tile 'down' 'true' ;;
-      l|$'\x1b\x5b\x43')
-        move_tile 'right' 'true' ;;
-      h|$'\x1b\x5b\x44')
-        move_tile 'left' 'true' ;;
+      k | $'\x1b\x5b\x41')
+        move_tile 'up' 'true'
+        ;;
+      j | $'\x1b\x5b\x42')
+        move_tile 'down' 'true'
+        ;;
+      l | $'\x1b\x5b\x43')
+        move_tile 'right' 'true'
+        ;;
+      h | $'\x1b\x5b\x44')
+        move_tile 'left' 'true'
+        ;;
     esac
     local wids_hash=$(echo -n "${WIDS[@]}" | md5sum | cut -d' ' -f1)
     if [ "$wids_hash" = "$collect_hash" ]; then break; fi
@@ -323,17 +342,16 @@ clean_up() {
   exit 0
 }
 
-
 processes=$(ps -ef | grep $WINDOW_NAME | grep -v grep)
 if [ $(echo "$processes" | wc -l) -le 2 ]; then
   # parent window
   initialize
   set_root_window
-  trap clean_up 2  # 2:SIGINT
+  trap clean_up 2 # 2:SIGINT
   create_children
   xdotool windowactivate $root_wid
   xdotool windowfocus $root_wid
-  wids=$(xdotool search --name "$WINDOW_NAME")  # newline separated
+  wids=$(xdotool search --name "$WINDOW_NAME") # newline separated
   child_wids=$(echo "$wids" | grep -v $root_wid | tr '\n' ' ')
   relocate "$root_wid $child_wids"
   draw "$child_wids"

--- a/bin/unko.shout
+++ b/bin/unko.shout
@@ -6,9 +6,9 @@ u="${U:-💩}" # Unko
 e="${E:-👁}" # Eyes
 n="${N:-👃}" # Nose
 m="${M:-👄}" # Mouth
-l="${L:-（}" # Left side
-r="${R:-）}" # Right side
-s="${S:-　}" # Space
+l="${L:-（}"  # Left side
+r="${R:-）}"  # Right side
+s="${S:-　}"  # Space
 cat << EOF
 $s$s$s$s$s$s$t
 $s$s$s$s$l$u$u$u$r

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  formatter:
+    image: peterdavehello/shfmt
+    container_name: formatter
+    entrypoint:
+      - "shfmt"
+      - "--version"
+
+  linter:
+    image: koalaman/shellcheck
+    container_name: linter
+    entrypoint:
+      - "shellcheck"
+      - "--version"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -ue
 
-readonly THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")" && pwd)"
+THIS_DIR=$(
+  cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd
+)
+readonly THIS_DIR
 readonly BINMODE=755
 readonly LIBMODE=644
 readonly PREFIX="${1:-/usr/local}"

--- a/linter.sh
+++ b/linter.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE:-$0}")"
+readonly SCRIPT_NAME
+
+# Dockerコンテナ系の定数
+readonly FORMATTER_IMAGE=peterdavehello/shfmt
+readonly LINTER_IMAGE=koalaman/shellcheck
+readonly CONTAINER_DIR_PREFIX=/work
+
+# 着色系ANSIエスケープシーケンス
+readonly RED=$'\x1b[31m'
+readonly GREEN=$'\x1b[32m'
+readonly RESET=$'\x1b[m'
+
+# デフォルトの静的解析対象
+readonly DEFAULT_TARGET_FILES=(*.sh bin/*)
+
+test_count=0
+err_count=0
+
+main() {
+  # 引数なしのときはヘルプを出力して終了
+  if [[ $# -lt 1 ]]; then
+    usage >&2
+    return 1
+  fi
+
+  while ((0 < $#)); do
+    local opt=$1
+    shift
+
+    case "$opt" in
+      help)
+        usage
+        return
+        ;;
+      setup)
+        # フォーマットとlintに使うDockerイメージを取得
+        docker-compose up
+        ;;
+      rebuild)
+        # フォーマットとlintに使うDockerイメージを強制的に取得
+        docker-compose up --force-recreate
+        ;;
+      format)
+        # コードフォーマットにかける
+        overwrite=""
+        cmd_format "$@"
+        print_check_result
+        return $?
+        ;;
+      format-save)
+        # コードフォーマットにかけて上書き保存
+        overwrite="-w"
+        cmd_format "$@"
+        print_check_result
+        return $?
+        ;;
+      lint)
+        # 静的解析
+        cmd_lint "$@"
+        print_check_result
+        return $?
+        ;;
+      all)
+        # コードフォーマット＋静的解析
+        cmd_format "$@"
+        cmd_lint "$@"
+        print_check_result
+        return $?
+        ;;
+      *)
+        usage >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+usage() {
+  cat << EOS
+$SCRIPT_NAME はプロジェクト内のシェルスクリプトのコードスタイルチェックをします。
+
+Usage:
+    $SCRIPT_NAME <command>
+
+Available commands:
+    help                      このヘルプを出力する。
+    setup                     リントツールをセットアップする。
+    rebuild                   リントツールを再セットアップする。
+                              Dockerfileが更新されたときに実行する。
+    format      [files...]    コードフォーマットにかける。
+    format-save [files...]    コードフォーマットして上書き保存する。
+    lint        [files...]    リントにかける。
+    all                       プロジェクト全体をフォーマットとリントにかける。
+EOS
+}
+
+## フォーマットにかけるサブコマンド。
+cmd_format() {
+  # 引数（ファイル）の指定があればそのファイルを解析する
+  # なければデフォルト指定（プロジェクト全体）のファイルを解析する
+  local files=("${DEFAULT_TARGET_FILES[@]}")
+  if [[ 0 -lt $# ]]; then
+    files=("$@")
+  fi
+
+  # テストするファイルの件数を加算
+  test_count=$((test_count + ${#files[@]}))
+
+  # コンテナ内のマウントディレクトリのフルパスに変更
+  local fullpath_files=()
+  for f in "${files[@]}"; do
+    fullpath_files+=("$CONTAINER_DIR_PREFIX/$f")
+  done
+
+  run_shfmt "$f" "$FORMATTER_IMAGE" "${fullpath_files[@]}"
+}
+
+## フォーマットにかける。
+run_shfmt() {
+  local f=$1
+  local img=$2
+  shift 2
+  local files=("$@")
+  local ret
+  docker run \
+    -v "$PWD:$CONTAINER_DIR_PREFIX" \
+    -it "$img" \
+    shfmt $overwrite -i 2 -ci -sr -d "${files[@]}"
+  ret=$?
+  if [[ "$ret" -ne 0 ]]; then
+    err_count=$((err_count + 1))
+  fi
+}
+
+## 静的解析にかけるサブコマンド。
+cmd_lint() {
+  # 引数（ファイル）の指定があればそのファイルを解析する
+  # なければデフォルト指定（プロジェクト全体）のファイルを解析する
+  local files=("${DEFAULT_TARGET_FILES[@]}")
+  if [[ 0 -lt $# ]]; then
+    files=("$@")
+  fi
+
+  # テストするファイルの件数を加算
+  test_count=$((test_count + ${#files[@]}))
+
+  # コンテナ内のマウントディレクトリのフルパスに変更
+  local fullpath_files=()
+  for f in "${files[@]}"; do
+    # unko.puzzleはスキップする
+    if [[ "$f" =~ ^.*unko.puzzle$ ]]; then
+      continue
+    fi
+    fullpath_files+=("$CONTAINER_DIR_PREFIX/$f")
+  done
+
+  run_shellcheck "$f" "$LINTER_IMAGE" "${fullpath_files[@]}"
+}
+
+## 静的解析にかける。
+run_shellcheck() {
+  local f=$1
+  local img=$2
+  shift 2
+  local files=("$@")
+  local ret
+  docker run \
+    -v "$PWD:$CONTAINER_DIR_PREFIX" \
+    -it "$img" \
+    "${files[@]}"
+  ret=$?
+  if [[ "$ret" -ne 0 ]]; then
+    err_count=$((err_count + 1))
+  fi
+}
+
+## テストの結果を出力する。
+print_check_result() {
+  echo "--------------------------------------------------------------------------------"
+  if [[ "$err_count" -lt 1 ]]; then
+    echo -e "[ ${GREEN}PASS${RESET} ] ($test_count/$test_count) all lint were passed."
+    return
+  else
+    echo -e "[ ${RED}FAIL${RESET} ] lint were failed."
+    return 1
+  fi
+}
+
+main ${1+"$@"}
+exit $?

--- a/package.sh
+++ b/package.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -ue
-readonly THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")" && pwd)"
+THIS_DIR=$(
+  cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd
+)
+readonly THIS_DIR
 {
   cd "${THIS_DIR}"
-  tar zcvf super_unko.tar.gz -C "$THIS_DIR" bin lib .tar2package.yml \
-    && docker run -i greymd/tar2rpm < super_unko.tar.gz > pkg/super_unko.rpm \
-    && docker run -i greymd/tar2deb < super_unko.tar.gz > pkg/super_unko.deb \
-    && rm super_unko.tar.gz
+  tar zcvf super_unko.tar.gz -C "$THIS_DIR" bin lib .tar2package.yml &&
+    docker run -i greymd/tar2rpm < super_unko.tar.gz > pkg/super_unko.rpm &&
+    docker run -i greymd/tar2deb < super_unko.tar.gz > pkg/super_unko.deb &&
+    rm super_unko.tar.gz
 }

--- a/test.sh
+++ b/test.sh
@@ -63,7 +63,7 @@ Available commands:
 Available test scripts:
 EOS
   for test_script in *-test.bats; do
-    sed 's/-test.bats//g' <<< "    $test_script"
+    echo "${test_script//-test.bats/}"
   done
 }
 

--- a/test.sh
+++ b/test.sh
@@ -29,14 +29,14 @@ main() {
   local cmd="$1"
 
   # ヘルプの出力
-  if [[ "$cmd" = help ]]; then
+  if [[ "$cmd" == help ]]; then
     usage
     return
   fi
 
   # マッチするコマンドのみ実行
   for test_script in *-test.bats; do
-    if [[ "$cmd"-test.bats = "$test_script" ]]; then
+    if [[ "$cmd"-test.bats == "$test_script" ]]; then
       echo -e "${BLUE}${test_script}${RESET}"
       ./"$test_script"
       ret=$?


### PR DESCRIPTION
shfmtとshellcheckのDockerイメージを利用してコマンドを実行する
静的解析ツールを追加して、それ経由でCIを回すようにしました。

また、READMEにもlinter.shを使う方法について記載しました。
これで、PRの際にlinter.shで各自の環境で静的解析できるようになると思います。

ご確認のほどよろしくお願いいたします。