### PR TITLE
unko.towerのメッセージに / が含まれると置換に失敗する不具合を修正 #47

### DIFF
--- a/bin/unko.tower
+++ b/bin/unko.tower
@@ -11,7 +11,12 @@ repeat_str() {
   shift
   local _str="$1"
   shift
-  printf "%${_num}s\\n" "" | sed "s/ /${_str}/g"
+  awk \
+    -v NUM="$_num" \
+    -v STR="$_str" \
+    'END{ for (i=0; i<NUM; i++) { printf "%s", STR } }' \
+    <<< ""
+  echo
 }
 
 print_unko() {

--- a/bin/unko.tower
+++ b/bin/unko.tower
@@ -14,8 +14,7 @@ repeat_str() {
   awk \
     -v NUM="$_num" \
     -v STR="$_str" \
-    'END{ for (i=0; i<NUM; i++) { printf "%s", STR } }' \
-    <<< ""
+    'BEGIN{ for (i=0; i<NUM; i++) { printf "%s", STR } }'
   echo
 }
 

--- a/test/unko.tower-test.bats
+++ b/test/unko.tower-test.bats
@@ -2,7 +2,7 @@
 
 readonly TARGET_COMMAND="../bin/unko.tower"
 
-@test "unko.towerは引数なしのときは3段" {
+@test 'unko.towerは引数なしのときは3段' {
   run "$TARGET_COMMAND"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　人" ]
@@ -11,7 +11,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（　　　　　　　）" ]
 }
 
-@test "unko.towerで引数2" {
+@test 'unko.towerで引数2' {
   run "$TARGET_COMMAND" 2
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　人" ]
@@ -19,7 +19,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[2]}" = "　（　　　　　）" ]
 }
 
-@test "unko.towerで引数4" {
+@test 'unko.towerで引数4' {
   run "$TARGET_COMMAND" 4
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　　人" ]
@@ -29,7 +29,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[4]}" = "　（　　　　　　　　　）" ]
 }
 
-@test "unko.towerでメッセージを埋め込む" {
+@test 'unko.towerでメッセージを埋め込む' {
   run "$TARGET_COMMAND" -s あい
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　人" ]
@@ -38,7 +38,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（あいあいあいあ）" ]
 }
 
-@test "unko.towerで先頭から文字数分だけメッセージを埋め込む" {
+@test 'unko.towerで先頭から文字数分だけメッセージを埋め込む' {
   run "$TARGET_COMMAND" -m あい
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　人" ]
@@ -47,7 +47,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（　　　　　　　）" ]
 }
 
-@test "unko.towerで半角文字は全角文字１つ分で置換される" {
+@test 'unko.towerで半角文字は全角文字１つ分で置換される' {
   run "$TARGET_COMMAND" -m ab
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　人" ]
@@ -56,7 +56,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（　　　　　　　）" ]
 }
 
-@test "unko.tower -mで置換文字に/が含まれていても置換できる" {
+@test 'unko.tower -mで置換文字に/が含まれていても置換できる' {
   run "$TARGET_COMMAND" -m /
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　人" ]
@@ -65,7 +65,7 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（　　　　　　　）" ]
 }
 
-@test "unko.tower -sで置換文字に/が含まれていても置換できる" {
+@test 'unko.tower -sで置換文字に/が含まれていても置換できる' {
   run "$TARGET_COMMAND" -s /
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "　　　　　人" ]
@@ -74,18 +74,17 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（/ / / / / / / ）" ]
 }
 
-@test "unko.tower -sで置換文字に\\が含まれていても置換できる" {
+@test 'unko.tower -sで置換文字に\\が含まれていても置換できる' {
   run "$TARGET_COMMAND" -s '\\'
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "　　　　　人" ]
-  [ "${lines[1]}" = "　　　（\ \ \ ）" ]
-  [ "${lines[2]}" = "　　（\ \ \ \ \ ）" ]
-  [ "${lines[3]}" = "　（\ \ \ \ \ \ \ ）" ]
+  [ "${lines[0]}" = '　　　　　人' ]
+  [ "${lines[1]}" = '　　　（\ \ \ ）' ]
+  [ "${lines[2]}" = '　　（\ \ \ \ \ ）' ]
+  [ "${lines[3]}" = '　（\ \ \ \ \ \ \ ）' ]
 }
 
-@test "unko.tower -sASCIIコード表33~127までの全ての文字は半角文字として扱う (\\は除外)" {
+@test 'unko.tower -sASCIIコード表33~127までの全ての文字は半角文字として扱う (\\は除外)' {
   grep -o . <<< '!"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~' | while read -r ch; do
-    echo "ch = $ch"
     run "$TARGET_COMMAND" -s "$ch"
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "　　　　　人" ]

--- a/test/unko.tower-test.bats
+++ b/test/unko.tower-test.bats
@@ -47,3 +47,51 @@ readonly TARGET_COMMAND="../bin/unko.tower"
   [ "${lines[3]}" = "　（　　　　　　　）" ]
 }
 
+@test "unko.towerで半角文字は全角文字１つ分で置換される" {
+  run "$TARGET_COMMAND" -m ab
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "　　　　　人" ]
+  [ "${lines[1]}" = "　　　（a b 　）" ]
+  [ "${lines[2]}" = "　　（　　　　　）" ]
+  [ "${lines[3]}" = "　（　　　　　　　）" ]
+}
+
+@test "unko.tower -mで置換文字に/が含まれていても置換できる" {
+  run "$TARGET_COMMAND" -m /
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "　　　　　人" ]
+  [ "${lines[1]}" = "　　　（/ 　　）" ]
+  [ "${lines[2]}" = "　　（　　　　　）" ]
+  [ "${lines[3]}" = "　（　　　　　　　）" ]
+}
+
+@test "unko.tower -sで置換文字に/が含まれていても置換できる" {
+  run "$TARGET_COMMAND" -s /
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "　　　　　人" ]
+  [ "${lines[1]}" = "　　　（/ / / ）" ]
+  [ "${lines[2]}" = "　　（/ / / / / ）" ]
+  [ "${lines[3]}" = "　（/ / / / / / / ）" ]
+}
+
+@test "unko.tower -sで置換文字に\\が含まれていても置換できる" {
+  run "$TARGET_COMMAND" -s '\\'
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "　　　　　人" ]
+  [ "${lines[1]}" = "　　　（\ \ \ ）" ]
+  [ "${lines[2]}" = "　　（\ \ \ \ \ ）" ]
+  [ "${lines[3]}" = "　（\ \ \ \ \ \ \ ）" ]
+}
+
+@test "unko.tower -sASCIIコード表33~127までの全ての文字は半角文字として扱う (\\は除外)" {
+  grep -o . <<< '!"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~' | while read -r ch; do
+    echo "ch = $ch"
+    run "$TARGET_COMMAND" -s "$ch"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "　　　　　人" ]
+    [ "${lines[1]}" = "　　　（$ch $ch $ch ）" ]
+    [ "${lines[2]}" = "　　（$ch $ch $ch $ch $ch ）" ]
+    [ "${lines[3]}" = "　（$ch $ch $ch $ch $ch $ch $ch ）" ]
+  done
+}
+


### PR DESCRIPTION
* `sed` の置換式内で使用する変数に `/` が含まれると置換に失敗していたので`sed` を使わない形に修正
* テストコードの追加