### PR TITLE
docker-compose.ymlを整理

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,11 @@ before_install:
   - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
 
 install:
-    ## Build base image and linter image and formatter image
   - mkdir -p $CACHE_DIR
-  - docker-compose build --parallel
+    ## Build super_unko image
+  - docker-compose build
+    ## Build linter and formatter image
+  - docker-compose -f docker-compose-tools.yml build linter formatter
     ## Build CI image
   - docker-compose -f docker-compose-ci.yml build ci_sh_${SH_VERSION}
     ## kcov

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean: ## Clear files
 
 .PHONY: setup
 setup: ## Setup super_unko, linter, formatter and coverage tools docker image
-	docker-compose build --parallel
+	docker-compose build
 	docker-compose -f docker-compose-ci.yml build --parallel
 
 .PHONY: test-bash-version

--- a/Makefile
+++ b/Makefile
@@ -2,37 +2,29 @@
 default: usage
 
 .PHONY: usage
-usage:
-	@ echo 'Usage: $(MAKE) TARGET ...'
-	@ echo
-	@ echo 'Targets:'
-	@ echo '  check                Run tests and linter'
-	@ echo '  test                 Run tests'
-	@ echo '  lint                 Run linter'
-	@ echo '  package              Build packages'
-	@ echo '  build-containers     Build docker images'
-	@ echo '  test-bash-version    Run tests on some Bash version'
+usage: ## Print this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: check
-check: test lint
+check: test lint ## Run tests and linter
 
 .PHONY: lint
-lint:
+lint: ## Run linter
 	./linter.sh all
 
 .PHONY: test
-test:
+test: ## Run tests
 	docker-compose -f docker-compose-ci.yml run --rm ci_sh_5.0
 
 .PHONY: clean
-clean:
+clean: ## Clear files
 	$(RM) super_unko.tar.gz pkg/*.tmp
 
 .PHONY: setup
-setup:
+setup: ## Setup super_unko, linter, formatter and coverage tools docker image
 	docker-compose build --parallel
 	docker-compose -f docker-compose-ci.yml build --parallel
 
 .PHONY: test-bash-version
-test-bash-version:
+test-bash-version: ## Run tests all bash version
 	docker-compose -f docker-compose-ci.yml up

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,24 @@ clean: ## Clear files
 	$(RM) super_unko.tar.gz pkg/*.tmp
 
 .PHONY: setup
-setup: ## Setup super_unko, linter, formatter and coverage tools docker image
-	docker-compose build
-	docker-compose -f docker-compose-ci.yml build --parallel
+setup: ## Setup super_unko, linter, formatter and testing docker image
+	docker-compose \
+		-f docker-compose.yml \
+		-f docker-compose-ci.yml \
+		-f docker-compose-tools.yml \
+		build \
+			super_unko \
+			formatter \
+			linter \
+			ci_sh_5.0
+
+.PHONY: setup-all
+setup-all: ## Setup all docker images
+	docker-compose \
+		-f docker-compose.yml \
+		-f docker-compose-ci.yml \
+		-f docker-compose-tools.yml \
+		build
 
 .PHONY: test-bash-version
 test-bash-version: ## Run tests all bash version

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -6,6 +6,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: default
+    image: unkontributors/super_unko/ci_sh_default:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -17,6 +18,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 3.2
+    image: unkontributors/super_unko/ci_sh_3.2:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -28,6 +30,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 4.0
+    image: unkontributors/super_unko/ci_sh_4.0:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -39,6 +42,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 4.1
+    image: unkontributors/super_unko/ci_sh_4.1:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -50,6 +54,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 4.2
+    image: unkontributors/super_unko/ci_sh_4.2:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -61,6 +66,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 4.3
+    image: unkontributors/super_unko/ci_sh_4.3:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -72,6 +78,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 4.4
+    image: unkontributors/super_unko/ci_sh_4.4:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko
@@ -83,6 +90,7 @@ services:
       context: ./build/ci
       args:
         SH_VERSION: 5.0
+    image: unkontributors/super_unko/ci_sh_5.0:latest
     volumes:
       - "$PWD:/usr/local/src/super_unko"
     working_dir: /usr/local/src/super_unko

--- a/docker-compose-tools.yml
+++ b/docker-compose-tools.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  formatter:
+    image: peterdavehello/shfmt
+    container_name: formatter
+    volumes:
+      - "$PWD:/work"
+    entrypoint:
+      - "shfmt"
+      - "-i"
+      - "2"
+      - "-ci"
+      - "-sr"
+      - "-d"
+
+  linter:
+    image: koalaman/shellcheck
+    container_name: linter
+    volumes:
+      - "$PWD:/work"
+    entrypoint:
+      - "shellcheck"

--- a/docker-compose-tools.yml
+++ b/docker-compose-tools.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   formatter:
-    image: peterdavehello/shfmt
+    image: peterdavehello/shfmt:2.6.4
     container_name: formatter
     volumes:
       - "$PWD:/work"
@@ -15,7 +15,7 @@ services:
       - "-d"
 
   linter:
-    image: koalaman/shellcheck
+    image: koalaman/shellcheck:stable
     container_name: linter
     volumes:
       - "$PWD:/work"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,24 +6,3 @@ services:
       context: ./
       dockerfile: ./build/super_unko/Dockerfile
     image: unkontributors/super_unko
-
-  formatter:
-    image: peterdavehello/shfmt
-    container_name: formatter
-    volumes:
-      - "$PWD:/work"
-    entrypoint:
-      - "shfmt"
-      - "-i"
-      - "2"
-      - "-ci"
-      - "-sr"
-      - "-d"
-
-  linter:
-    image: koalaman/shellcheck
-    container_name: linter
-    volumes:
-      - "$PWD:/work"
-    entrypoint:
-      - "shellcheck"

--- a/linter.sh
+++ b/linter.sh
@@ -14,6 +14,9 @@ readonly RESET=$'\x1b[m'
 # デフォルトの静的解析対象
 readonly DEFAULT_TARGET_FILES=(*.sh bin/*)
 
+# docker-composeコマンド
+readonly DC_CMD=(docker-compose -f docker-compose-tools.yml)
+
 test_count=0
 err_count=0
 
@@ -35,7 +38,7 @@ main() {
         ;;
       setup)
         # フォーマットとlintに使うDockerイメージを取得
-        docker-compose pull formatter linter
+        "${DC_CMD[@]}" pull formatter linter
         ;;
       format)
         # コードフォーマットにかける
@@ -114,7 +117,7 @@ cmd_format() {
 run_shfmt() {
   local files=("$@")
   local ret
-  docker-compose run formatter $overwrite "${files[@]}"
+  "${DC_CMD[@]}" run formatter $overwrite "${files[@]}"
   ret=$?
   if [[ "$ret" -ne 0 ]]; then
     err_count=$((err_count + 1))
@@ -150,7 +153,7 @@ cmd_lint() {
 run_shellcheck() {
   local files=("$@")
   local ret
-  docker-compose run linter "${files[@]}"
+  "${DC_CMD[@]}" run linter "${files[@]}"
   ret=$?
   if [[ "$ret" -ne 0 ]]; then
     err_count=$((err_count + 1))

--- a/linter.sh
+++ b/linter.sh
@@ -117,7 +117,7 @@ cmd_format() {
 run_shfmt() {
   local files=("$@")
   local ret
-  "${DC_CMD[@]}" run formatter $overwrite "${files[@]}"
+  "${DC_CMD[@]}" run --rm formatter $overwrite "${files[@]}"
   ret=$?
   if [[ "$ret" -ne 0 ]]; then
     err_count=$((err_count + 1))
@@ -153,7 +153,7 @@ cmd_lint() {
 run_shellcheck() {
   local files=("$@")
   local ret
-  "${DC_CMD[@]}" run linter "${files[@]}"
+  "${DC_CMD[@]}" run --rm linter "${files[@]}"
   ret=$?
   if [[ "$ret" -ne 0 ]]; then
     err_count=$((err_count + 1))


### PR DESCRIPTION
* docker-compose.ymlからformatterとshfmtを削除してtools.ymlファイルに分離
* `make setup` 時に全部のBashイメージを作成していたのをBash5.0イメージだけビルドするように変更
* 全Dockerイメージをビルドする `setup-all` タスクを追加
* parallelオプションは非推奨なので削除
* `docker-compose run` 時に `--rm` で削除するように変更
* イメージビルド時に複数回docker-composeを実行するのではなく `-f` でつないで一回でビルドするように変更
  * 並列ビルドの恩恵を受けられるため