### PR TITLE
GitHubReleaseの画面からリリースドラフトをPublishするとdeb, rpmファイルがリリースされるCIフローを追加 #64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF:10}
+      - name: Set tag to .tar2package.yml
+        run: sed -i 's:\$VERSION:${{ steps.vars.outputs.tag }}:g' .tar2package.yml
+      - run: Print .tar2package.yml
+      - name: Generate packages
+        run: ./package.sh
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files:
+            - pkg/*.deb
+            - pkg/*.rpm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/unko.yml
+++ b/.github/workflows/unko.yml
@@ -60,3 +60,21 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run lint
         run: ./linter.sh lint
+
+  update-packages:
+    runs-on: ubuntu-latest
+    needs: [test, format, lint]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v1
+      - name: Generate packages
+        run: ./package.sh
+      - name: Git commit
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "update pkg/super_unko.deb and pkg/super_unko.rpm" -a
+      - name: Git push
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unko.yml
+++ b/.github/workflows/unko.yml
@@ -73,13 +73,20 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v1
+      - name: Set latest tag version to output
+        id: vars
+        run: echo ::set-output name=tag::$(git tag -l '*.*.*' | sort -V | tail -n 1)
+      - name: Set tag version to .tar2package.yml
+        run: sed -i 's:\$VERSION:${{ steps.vars.outputs.tag }}:g' .tar2package.yml
+      - run: Print .tar2package.yml
       - name: Generate packages
         run: ./package.sh
       - name: Git commit
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git commit -m "update pkg/super_unko.deb and pkg/super_unko.rpm" -a
+          git add pkg/*
+          git commit -m "update pkg/super_unko.deb and pkg/super_unko.rpm"
       - name: Git push
         uses: ad-m/github-push-action@v0.5.0
         with:

--- a/.github/workflows/unko.yml
+++ b/.github/workflows/unko.yml
@@ -1,6 +1,12 @@
 name: test
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'LICENSE'
+      - 'README.*'
+      - 'doc/*.md'
+      - 'pkg/*'
 
 jobs:
   build-image:

--- a/.github/workflows/unko.yml
+++ b/.github/workflows/unko.yml
@@ -1,4 +1,4 @@
-name: Test bash each version
+name: test
 
 on: [push]
 

--- a/.tar2package.yml
+++ b/.tar2package.yml
@@ -2,7 +2,7 @@ name : superunko
 cmdname : superunko
 summary : Super Unko
 description : super_unko project is the one of the awesome, clean and sophisticated OSS project in the world. Let us create shit commands.
-version : 1.0.5
+version : $VERSION
 changelog : unko.tower power up
 url : https://github.com/unkontributors/super_unko
 author : Awesome Unkontributors

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Installation
 #### With `yum` (RHEL compatible distros)
 
 ```
-$ sudo yum install https://git.io/superunko.rpm
+$ sudo yum install https://github.com/unkontributors/super_unko/releases/download/1.0.6/super_unko.rpm
 ```
 
 Uninstall (not `super_unko`)
@@ -56,7 +56,7 @@ $ sudo yum remove superunko
 #### With `apt` (Debian base distros)
 
 ```
-$ wget https://git.io/superunko.deb
+$ wget https://github.com/unkontributors/super_unko/releases/download/1.0.6/super_unko.deb
 $ sudo dpkg -i ./superunko.deb
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ super_unko
 [![License](https://img.shields.io/badge/license-%F0%9F%92%A9-orange.svg)](./LICENSE)
 [![Build Status](https://travis-ci.org/unkontributors/super_unko.svg?branch=master)](https://travis-ci.org/unkontributors/super_unko)
 [![Coverage Status](https://coveralls.io/repos/github/unkontributors/super_unko/badge.svg?branch=master)](https://coveralls.io/github/unkontributors/super_unko?branch=master)
-![GitHub Actions Build Status](https://github.com/unkontributors/super_unko/workflows/Test%20bash%20each%20version/badge.svg)
+![GitHub Actions Build Status](https://github.com/unkontributors/super_unko/workflows/test/badge.svg)
 
 super_unko project is the one of the awesome, clean and sophisticated OSS project in the world.
 Let's create shit commands!

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Installation
 #### With `yum` (RHEL compatible distros)
 
 ```
-$ sudo yum install https://github.com/unkontributors/super_unko/releases/download/1.0.6/super_unko.rpm
+$ sudo yum install https://git.io/superunko.rpm
 ```
 
 Uninstall (not `super_unko`)
@@ -56,7 +56,7 @@ $ sudo yum remove superunko
 #### With `apt` (Debian base distros)
 
 ```
-$ wget https://github.com/unkontributors/super_unko/releases/download/1.0.6/super_unko.deb
+$ wget https://git.io/superunko.deb
 $ sudo dpkg -i ./superunko.deb
 ```
 


### PR DESCRIPTION
## 内容

* super_unko.deb, super_unko.rpmをGitHubReleaseにアップするCIフローを追加
  * [こちらの画面](https://github.com/unkontributors/super_unko/releases)で新しいリリースタグを切ると、切ったリリースタグ名を.tar2package.ymlに埋め込んでpackage.shを実行する
  * 例
    1. 1.0.6というリリースタグドラフトを作成する
    1. リリースタグドラフトに更新内容を記載する（なくてもいい）
    1. リリースタグドラフトをPublishする
    1. PublishをトリガーにCIが実行される
    1. Publishしたリリースにdeb, rpmファイルがアップロードされる

## 補足

* 本当はmaster更新時にリリースされるようにしたかったのですが、
  バージョン番号を誰がいつ決めるのか、という問題があったのでそちらの方法は諦めました