### PR TITLE
ArchLinux で unko.say と unko.think が文字化けしていたのを修正

### DIFF
--- a/bin/unko.say
+++ b/bin/unko.say
@@ -9,13 +9,10 @@ readonly THIS_DIR
 LIB_DIR="${THIS_DIR}/../lib/super_unko"
 readonly LIB_DIR
 
-case ${OSTYPE} in
-  darwin*)
-    COW_FILE="${LIB_DIR}/unko_mb.cow"
-    ;;
-  *)
-    COW_FILE="${LIB_DIR}/unko.cow"
-    ;;
-esac
+COW_FILE="${LIB_DIR}/unko_mb.cow"
+if ! (cowsay -f "${COW_FILE}" 'うんこ' | grep -qe 'うんこ' &&
+  cowsay -f "${COW_FILE}" 'もりもり' | grep -qe '💩'); then
+  COW_FILE="${LIB_DIR}/unko.cow"
+fi
 
 cowsay -f "${COW_FILE}" "$@"

--- a/bin/unko.think
+++ b/bin/unko.think
@@ -9,13 +9,10 @@ readonly THIS_DIR
 LIB_DIR="${THIS_DIR}/../lib/super_unko"
 readonly LIB_DIR
 
-case ${OSTYPE} in
-  darwin*)
-    COW_FILE="${LIB_DIR}/unko_mb.cow"
-    ;;
-  *)
-    COW_FILE="${LIB_DIR}/unko.cow"
-    ;;
-esac
+COW_FILE="${LIB_DIR}/unko_mb.cow"
+if ! (cowsay -f "${COW_FILE}" 'うんこ' | grep -qe 'うんこ' &&
+  cowsay -f "${COW_FILE}" 'もりもり' | grep -qe '💩'); then
+  COW_FILE="${LIB_DIR}/unko.cow"
+fi
 
 cowthink -f "${COW_FILE}" "$@"


### PR DESCRIPTION
## Check list

* [X] Were all tests passed of CI?
  * (Case: failing `test`) Please run tests and fix your code (see also: [Testing](https://github.com/unkontributors/super_unko/blob/oshiri/README.md#testing))
  * (Case: failing `format`) Please run `./linter.sh format-save` (see also: [CodeStyle and lint](https://github.com/unkontributors/super_unko/blob/oshiri/README.md#codestyle-and-lint))
  * (Case: failing `lint`) Please run linter and fix your code (see also: [CodeStyle and lint](https://github.com/unkontributors/super_unko/blob/oshiri/README.md#codestyle-and-lint))
* [x] (Case: adding new command) Were tests added to cover new commands ?
* [x] (Case: adding new command) Were descriptions for new commands added to README?

## 目的
ArchLinux の cowsay はマルチバイト対応しているらしく、今の `OSTYPE` を見る実装だと文字化けしてしまいます。

```
❱❱ unko.say 💩うんこLinux💩
 ________________________
< ð©ãããLinuxð© >
 ------------------------
　　　　　　👑
　　　　（💩💩💩）
　　　（💩👁💩👁💩）
　　（💩💩💩👃💩💩💩）
　（💩💩💩💩👄💩💩💩💩）
```
これをなんとかします。



## 修正方法
cowsay を実行して、文字化けしてないか確認するように変えました。

```
❱❱ bin/unko.say 💩うんこLinux💩
 ________________________
< 💩うんこLinux💩 >
 ------------------------
　　　　　　👑
　　　　（💩💩💩）
　　　（💩👁💩👁💩）
　　（💩💩💩👃💩💩💩）
　（💩💩💩💩👄💩💩💩💩）
```
